### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ legitimate use case for private).
 ```groovy
 dependencies {
   ...
-  compile 'com.andrewreitz:shillelagh:0.5.0'
+  implementation 'com.andrewreitz:shillelagh:0.5.0'
   provided 'com.andrewreitz:shillelagh-processor:0.5.0'
   ...
 }


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.